### PR TITLE
Set execute permissions on script

### DIFF
--- a/R/lgb.dl.R
+++ b/R/lgb.dl.R
@@ -157,6 +157,9 @@ lgb.dl <- function(commit = "master",
       cat(paste0("cp ", libdll, " ", file.path(lgb_git_dir, "LightGBM"), "\n"), file = lgb_git_file, append = TRUE) # Move dll/lib
     }
     
+    #Set permissions on script
+    Sys.chmod(lgb_git_file, mode = "0777", use_umask = TRUE)
+    
     # Do actions
     system(lgb_git_file)
     


### PR DESCRIPTION
This sets execute permissions (0777) on the *.sh file. Hoping you're comfortable with this, 0777 is arguably a bit broad but the file exists for a very short period of time.

This fixes #1 